### PR TITLE
smaller chevron, mobile site indicator, change label to dev center > …

### DIFF
--- a/docs/src/components/Layout/GlobalNav/GlobalNav.tsx
+++ b/docs/src/components/Layout/GlobalNav/GlobalNav.tsx
@@ -158,7 +158,9 @@ export function GlobalNav({
             />
             <Text className={styles['dev-center-logo']}>
               <span style={{ fontWeight: '400' }}>Amplify</span>{' '}
-              <span style={{ fontWeight: '300' }}>{currentSite}</span>
+              <span style={{ fontWeight: '300' }}>Dev Center </span>
+              <ChevronIcon rotateDeg="270" />
+              <span style={{ fontWeight: '300' }}> {currentSite}</span>
             </Text>
           </Flex>
           <Button

--- a/docs/src/components/Layout/GlobalNav/components/NavMenuLink.tsx
+++ b/docs/src/components/Layout/GlobalNav/components/NavMenuLink.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@aws-amplify/ui-react';
+import { Button, Text } from '@aws-amplify/ui-react';
 import { useContext } from 'react';
 import styles from '../GlobalNav.module.scss';
 import { IconLink, ExternalLink } from '.';
@@ -47,7 +47,7 @@ export function NavMenuLink({
           border="none"
           borderRadius="0"
           padding="12px"
-          className={styles['secondary-nav-button']}
+          className={`${styles['secondary-nav-button']}`}
           {...(customKey ? { key: customKey } : {})}
           onClick={() => setShowGlobalNav(false)}
           ariaLabel={`Show ${linkContent} nav bar`}
@@ -60,7 +60,17 @@ export function NavMenuLink({
           {...(customKey ? { key: customKey } : {})}
           href={navMenuItem.url}
         >
-          {linkContent}
+          <Text
+            as="span"
+            padding="2px 10px"
+            className={
+              navMenuItem.label === currentMenuItem
+                ? styles['current-nav-menu-item']
+                : ''
+            }
+          >
+            {linkContent}
+          </Text>
         </a>
       );
     } else {

--- a/docs/src/components/Layout/GlobalNav/components/NavMenuLink.tsx
+++ b/docs/src/components/Layout/GlobalNav/components/NavMenuLink.tsx
@@ -47,7 +47,7 @@ export function NavMenuLink({
           border="none"
           borderRadius="0"
           padding="12px"
-          className={`${styles['secondary-nav-button']}`}
+          className={styles['secondary-nav-button']}
           {...(customKey ? { key: customKey } : {})}
           onClick={() => setShowGlobalNav(false)}
           ariaLabel={`Show ${linkContent} nav bar`}

--- a/docs/src/components/Layout/GlobalNav/components/icons/ChevronIcon.tsx
+++ b/docs/src/components/Layout/GlobalNav/components/icons/ChevronIcon.tsx
@@ -5,8 +5,8 @@ export function ChevronIcon({ rotateDeg }: { rotateDeg?: string }) {
   return (
     <Icon
       className={styles['chevron-icon']}
-      width="20"
-      height="18"
+      width="10"
+      height="9"
       viewBox={{ minX: 2, minY: -1.5, width: 11, height: 12 }}
       ariaLabel="Icon"
       fr={undefined}


### PR DESCRIPTION
These are the changes that were discussed by Rachel and Danny


<img width="64" alt="Screen Shot 2022-09-15 at 7 57 51 AM" src="https://user-images.githubusercontent.com/7351516/190439001-352352a7-8b77-483c-afbb-cba85fdc9f84.png">
<img width="338" alt="Screen Shot 2022-09-15 at 7 58 10 AM" src="https://user-images.githubusercontent.com/7351516/190439014-b236de76-f0a0-461e-ac70-a1afcef9d8e1.png">
<img width="118" alt="Screen Shot 2022-09-15 at 7 58 36 AM" src="https://user-images.githubusercontent.com/7351516/190439020-a0d87156-c856-44bc-9bcf-72a21ef5146e.png">
